### PR TITLE
Fixes related to pins at boot

### DIFF
--- a/OMEGA2-CHANGELOG.md
+++ b/OMEGA2-CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Log of changes made to the Onion Omega2 Bootloader
 
+* 2019-10-17
+    * GPIO2_MODE register now unchanged during init - all LED pins being left to default GPIO mode
+      * Resolves issue where GPIOs 39-42 flap right after boot
+* 2019-08-19
+    * EPHY P1-P4 pins set to digital (no more random voltages during boot), while still keeping P0 as ethernet port
+    * GPIO37 now works in gpio test
 * ~~2019-04-12~~
     * ~~Fix to ensure EPHY P1-P4 pins are **always** set to Digital Pads - Resolves issues where these pins had fluctuating voltages during boot~~
     * Reverted this change - new setting was disabling all ethernet ports, resulted in web recovery mode not working

--- a/drivers/rt2880_eth.c
+++ b/drivers/rt2880_eth.c
@@ -2149,7 +2149,8 @@ void rt305x_esw_init(void)
 	RALINK_REG(RT2880_RSTCTRL_REG) = i;
 
 	i = RALINK_REG(RALINK_SYSCTL_BASE + 0x64); // GPIO2_MODE register
-	i &= 0xf003f003; // WLED_AN_MODE = reserved, P0_LED_AN_MODE = EPHY P0 LED  // lazar@onion.io: potentiall change this??
+	// GPIO2_MODE POR = 0x05550555 - all LED pins set to GPIO mode
+	i &= 0xf557f557; // keep all LED pins set to GPIO mode
 	RALINK_REG(RALINK_SYSCTL_BASE + 0x64) = i;  // GPIO2_MODE register
 
       

--- a/drivers/rt2880_eth.c
+++ b/drivers/rt2880_eth.c
@@ -2133,12 +2133,11 @@ void rt305x_esw_init(void)
 #elif defined (MT7628_ASIC_BOARD)
 /*TODO: Init MT7628 ASIC PHY HERE*/
 	i = RALINK_REG(RT2880_AGPIOCFG_REG); // AGPIO_CFG register
-	// onion.io: fix to ensure EPHY P1-P4 pins are always set to Digital Pads (no random voltages on these pins during boot)
-	//#define MT7628_EPHY_EN	        (0x1f<<16)
+	// onion.io: fix to ensure EPHY P0 is enabled for ethernet & EPHY P1-P4 pins are always set to Digital Pads (no random voltages on these pins during boot)
+	#define MT7628_EPHY_EN	        (0x1f<<16)
     i = i & ~(MT7628_EPHY_EN);   // setting EPHY_P0_DIS to disabled (0b1) and EPHY_GPIO_AIO_EN to Digital Pad (0b1)	
     // only enable PHY 0
-    // lazar@onion.io: 2019-04-23 - switching back to previous setting, the below code caused all ethernet ports to be disabled, resulting in web recovery mode no longer working
-    //i = i | (0x1f << 16);
+    i = i | (0x1e << 16);
 	RALINK_REG(RT2880_AGPIOCFG_REG) = i;
 
 	printf("Resetting MT7628 PHY.\n");

--- a/lib_mips/board.c
+++ b/lib_mips/board.c
@@ -3102,10 +3102,11 @@ void gpio_test( int vtest ) //Test Omega2 GPIO
 	val|=0x01<<2;//p0 led Gpio43
 	val|=0x01<<0;//wled   GPIO44
 	RALINK_REG(RT2880_SYS_CNTL_BASE+0x64)=val;
-	//ctrl0,ctrl1
+	// set gpio ctrl0,ctrl1 reg - all gpios output
 	RALINK_REG(0xb0000600)=0xffffffff;
 	RALINK_REG(0xb0000604)=0xffffffff;
-	RALINK_REG(0xb0000604)&=~0x01<<6;
+	// switch GPIO37 to input
+	RALINK_REG(0xb0000604)&=~(0x01<<6);
 
 	udelay(600000);
 


### PR DESCRIPTION
Updates and fixes:
* GPIO2_MODE register now unchanged during init - all LED pins being left to default GPIO mode
      * Resolves issue where GPIOs 39-42 flap right after boot
* EPHY P1-P4 pins set to digital (no more random voltages during boot), while still keeping P0 as ethernet port
* GPIO37 direction in gpio test function now properly set